### PR TITLE
feat(tools): declare openWorldHint on every tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,10 @@ entirely within closed or private systems. Read-only tools change nothing, so th
 `false`.
 
 In this codebase that means `openWorldHint: true` for app installs/updates/uninstalls, certificate
-requests, container and stack operations, cronjobs (they run arbitrary code), DNS zone and
-virtualhost changes, mail address changes, organisation invitations (they send email) and project
-deletion. Everything else — databases, backups, volumes, registries, SSH/SFTP users, API tokens,
-memberships, delivery boxes — stays `false`.
+requests, container/stack deployments, DNS zone and virtualhost changes, mail address changes,
+organisation invitations (they send email) and project deletion. Everything else — databases,
+backups, volumes, registries, SSH/SFTP users, API tokens, memberships, delivery boxes, cronjobs and
+container lifecycle operations (start/stop/restart) — stays `false`.
 
 `tests/unit/tools/tool-annotations.test.ts` enforces this across the whole registry — it will fail
 if a new tool is missing a title or any of the three hints.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ const tool: Tool = {
     title: 'List Apps',        // mirrors the top-level title (legacy clients read this one)
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: '...',
   inputSchema: { /* ... */ },
@@ -127,8 +128,20 @@ const tool: Tool = {
 
 Never set both `readOnlyHint` and `destructiveHint` to `true`.
 
+**`openWorldHint` (required by the OpenAI integration):** for write tools, `true` if the tool can
+change publicly visible internet state — publishing content, changing what a public site or mail
+domain serves, pushing code, sending messages to third parties. `false` only if the tool operates
+entirely within closed or private systems. Read-only tools change nothing, so they are always
+`false`.
+
+In this codebase that means `openWorldHint: true` for app installs/updates/uninstalls, certificate
+requests, container and stack operations, cronjobs (they run arbitrary code), DNS zone and
+virtualhost changes, mail address changes, organisation invitations (they send email) and project
+deletion. Everything else — databases, backups, volumes, registries, SSH/SFTP users, API tokens,
+memberships, delivery boxes — stays `false`.
+
 `tests/unit/tools/tool-annotations.test.ts` enforces this across the whole registry — it will fail
-if a new tool is missing a title or either hint.
+if a new tool is missing a title or any of the three hints.
 
 ## Return Connection Data, Don't Execute - CRITICAL
 

--- a/src/constants/tool/mittwald-cli/app/copy-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/copy-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Copy App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Copy an app within a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/create/node-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/create/node-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Node.js App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a Node.js app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/create/php-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/create/php-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create PHP App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a PHP app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/create/php-worker-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/create/php-worker-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create PHP Worker App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a PHP worker app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/create/python-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/create/python-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Python App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a Python app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/create/static-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/create/static-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Static App',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a static app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/dependency-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/dependency-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List App Dependencies',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get all available system software dependencies and optionally filter by app type or installation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/dependency-update-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/dependency-update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update App Dependencies',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Update one or more system software dependencies for an app installation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/dependency-versions-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/dependency-versions-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Dependency Versions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Fetch available versions for a specific system software dependency.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get App Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details about an app installation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/contao-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/contao-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Contao",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Contao application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/joomla-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/joomla-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Joomla",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Joomla application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/matomo-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/matomo-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Matomo",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Matomo application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/nextcloud-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/nextcloud-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Nextcloud",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Nextcloud application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/shopware5-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/shopware5-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Shopware 5",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Shopware 5 application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/shopware6-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/shopware6-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install Shopware 6",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install Shopware 6 application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/typo3-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/typo3-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install TYPO3",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install TYPO3 application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/install/wordpress-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/install/wordpress-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Install WordPress",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Install WordPress application.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Apps',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List installed apps in a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/list-upgrade-candidates-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/list-upgrade-candidates-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List App Upgrade Candidates',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List upgrade candidates for an app installation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/ssh-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/ssh-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get App SSH Connection Data',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     'Get the SSH connection data (host, user, document root) for an app installation, plus a ready-to-run ssh command. ' +

--- a/src/constants/tool/mittwald-cli/app/uninstall-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/uninstall-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Uninstall App',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Uninstall an app.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update App Properties',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Update properties of an app installation. (use upgrade to update the app version)',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/upgrade-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/upgrade-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Upgrade App Version',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Upgrade app installation to target version.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/app/versions-cli.ts
+++ b/src/constants/tool/mittwald-cli/app/versions-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List App Versions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List supported Apps and Versions.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Backup',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new backup',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Backup',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a backup',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/download-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/download-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Backup Download URL',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     'Get the download URL for a backup, requesting an export first if none exists yet. ' +

--- a/src/constants/tool/mittwald-cli/backup/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Backup Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a backup',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Backups',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List backups',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/schedule-create-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/schedule-create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Backup Schedule',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a backup schedule.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/schedule-delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/schedule-delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Backup Schedule',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a backup schedule.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/schedule-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/schedule-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Backup Schedules',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List backup schedules.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/backup/schedule-update-cli.ts
+++ b/src/constants/tool/mittwald-cli/backup/schedule-update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update Backup Schedule',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Update a backup schedule.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/certificate/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/certificate/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List SSL Certificates",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List SSL/TLS certificates available for a domain.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/certificate/request-cli.ts
+++ b/src/constants/tool/mittwald-cli/certificate/request-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Request SSL Certificate",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: "Request a new SSL/TLS certificate for a domain using Let's Encrypt.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Container',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Delete a container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/list-services-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/list-services-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Containers',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List containers belonging to a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/logs-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/logs-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'View Container Logs',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Display logs of a specific container. Use mittwald_container_list to find the containerId for your container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/recreate-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/recreate-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Recreate Container',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Recreate a container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/restart-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/restart-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Restart Container',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Restart a container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/restart-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/restart-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Restart Container',
     readOnlyHint: false,
     destructiveHint: true,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Restart a container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/run-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/run-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Run Container',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create and start a new container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/start-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/start-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Start Container',
     readOnlyHint: false,
     destructiveHint: false,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Start a stopped container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/start-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/start-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Start Container',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Start a stopped container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/stop-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/stop-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Stop Container',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Stop a running container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/stop-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/stop-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Stop Container',
     readOnlyHint: false,
     destructiveHint: true,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Stop a running container.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/container/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/container/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update Container',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Updates attributes of an existing container such as image, environment variables, port mappings, and volumes.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/categories-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/categories-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Conversation Categories',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List conversation categories.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/close-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/close-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Close Conversation',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Close a conversation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Conversation',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a new conversation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Conversations',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List conversations.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/reply-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/reply-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Reply to Conversation',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Reply to a conversation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/conversation/show-cli.ts
+++ b/src/constants/tool/mittwald-cli/conversation/show-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Show Conversation Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Show details of a conversation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/create-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Create Cron Job',
     readOnlyHint: false,
     destructiveHint: false,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Create a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Cron Job',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Cron Job',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Delete a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/delete-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Delete Cron Job',
     readOnlyHint: false,
     destructiveHint: true,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execute-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execute-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Execute Cron Job',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Execute a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execute-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execute-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Execute Cron Job',
     readOnlyHint: false,
     destructiveHint: false,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Execute a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execution-abort-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execution-abort-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Abort Cron Job Execution',
     readOnlyHint: false,
     destructiveHint: true,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Abort a cronjob execution.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execution-abort-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execution-abort-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Abort Cron Job Execution',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Abort a cronjob execution.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execution-get-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execution-get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Cron Job Execution Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a cronjob execution.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execution-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execution-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Cron Job Executions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List cronjob executions.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/execution-logs-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/execution-logs-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Cron Job Execution Logs',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get logs of a cronjob execution.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Cron Job Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Cron Jobs',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List cronjobs.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update Cron Job',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Update a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/cronjob/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/cronjob/update-cli.ts
@@ -9,7 +9,7 @@ const tool: Tool = {
     title: 'Update Cron Job',
     readOnlyHint: false,
     destructiveHint: true,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   description: 'Update a cronjob.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List Databases",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all databases.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/charsets-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/charsets-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List MySQL Character Sets",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List available MySQL character sets and collations.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Create MySQL Database",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Create a new MySQL database.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Delete MySQL Database",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Delete a MySQL database.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/dump-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/dump-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get MySQL Dump Instructions",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     "Get a ready-to-run command that dumps a MySQL database via SSH and mysqldump into a local file. " +

--- a/src/constants/tool/mittwald-cli/database/mysql/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get MySQL Database Details",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Get a MySQL database.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/import-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/import-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get MySQL Import Instructions",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     "Get a ready-to-run command that imports a local dump file into a MySQL database via SSH. " +

--- a/src/constants/tool/mittwald-cli/database/mysql/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List MySQL Databases",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List MySQL databases.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/phpmyadmin-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/phpmyadmin-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get phpMyAdmin URL",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     "Get the phpMyAdmin URL for a MySQL database's main user. " +

--- a/src/constants/tool/mittwald-cli/database/mysql/port-forward-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/port-forward-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get MySQL Port Forwarding Instructions",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     "Get a ready-to-run SSH port forwarding command that exposes a MySQL database on a local TCP port. " +

--- a/src/constants/tool/mittwald-cli/database/mysql/user-create-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/user-create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create MySQL User',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new MySQL user for a database.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/user-delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/user-delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete MySQL User',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete an existing MySQL user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/user-get-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/user-get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get MySQL User',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Retrieve details for a specific MySQL user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/user-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/user-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List MySQL Users',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List MySQL users for a database.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/user-update-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/user-update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update MySQL User',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Update properties of an existing MySQL user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/mysql/versions-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/mysql/versions-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List MySQL Versions",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List available MySQL versions.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/redis/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/redis/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Redis Database',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Provision a new Redis database within a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/redis/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/redis/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Redis Database',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Retrieve details for a Redis database.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/redis/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/redis/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Redis Databases',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List Redis databases for a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/database/redis/versions-cli.ts
+++ b/src/constants/tool/mittwald-cli/database/redis/versions-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Redis Versions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List available Redis versions.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/ddev/render-config-cli.ts
+++ b/src/constants/tool/mittwald-cli/ddev/render-config-cli.ts
@@ -12,6 +12,7 @@ export const mittwald_ddev_render_config_cli: Tool = {
     title: 'Render DDEV Config',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Render DDEV configuration for an app installation.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/dnszone/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/dnszone/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get DNS Zone Details",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Get DNS zone information..",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/dnszone/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/dnszone/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List DNS Zones",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List DNS zones for a project..",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/dnszone/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/dnszone/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Update DNS Zone Records",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: "Update DNS zone records..",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get Domain Info",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Get domain information..",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List Domains",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List domains belonging to a project..",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/virtualhost-create-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/virtualhost-create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Virtual Host',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a domain virtualhost.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/virtualhost-delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/virtualhost-delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Virtual Host',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Delete a domain virtualhost.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/virtualhost-get-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/virtualhost-get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Virtual Host Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a domain virtualhost.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/domain/virtualhost-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/domain/virtualhost-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Virtual Hosts',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List domain virtualhosts.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/extension/install-cli.ts
+++ b/src/constants/tool/mittwald-cli/extension/install-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Install Extension',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Install an extension in a project or organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/extension/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/extension/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Available Extensions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all available extensions.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/extension/list-installed-cli.ts
+++ b/src/constants/tool/mittwald-cli/extension/list-installed-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Installed Extensions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List installed extensions in a project or organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/extension/uninstall-cli.ts
+++ b/src/constants/tool/mittwald-cli/extension/uninstall-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Uninstall Extension',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Remove an extension from an organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/address/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/address/create-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Create Mail Address',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Create a new mail address.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/address/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/address/delete-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Delete Mail Address',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Delete a mail address.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/address/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/address/get-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Get Mail Address Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get a specific mail address.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/address/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/address/list-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'List Mail Addresses',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all mail addresses for a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/address/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/address/update-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Update Mail Address',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Update a mail address.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/deliverybox/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/deliverybox/create-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Create Delivery Box',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new delivery box.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/deliverybox/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/deliverybox/delete-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Delete Delivery Box',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a delivery box.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/deliverybox/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/deliverybox/get-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Get Delivery Box Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get a specific delivery box.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/deliverybox/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/deliverybox/list-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'List Delivery Boxes',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all delivery boxes for a project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/mail/deliverybox/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/mail/deliverybox/update-cli.ts
@@ -14,6 +14,7 @@ const tool: Tool = {
     title: 'Update Delivery Box',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Update a delivery box.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Organization',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete an organization. This is a destructive operation and cannot be undone.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Organization',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get detailed information about a specific organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/invite-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/invite-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Invite User to Organization',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: true,
   },
   description: 'Invite a user to join an organization with a specified role.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/invite-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/invite-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List Organization Invites",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all invites for an organization.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/invite-list-own-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/invite-list-own-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List My Organization Invites",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all organization invites for the executing user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/invite-revoke-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/invite-revoke-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Revoke Organization Invite",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Revoke an invite to an organization.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Organizations',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get all organizations the authenticated user has access to.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/membership-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/membership-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Organization Members',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all memberships belonging to an organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/membership-list-own-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/membership-list-own-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My Organization Memberships',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all organization memberships for the authenticated user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/org/membership-revoke-cli.ts
+++ b/src/constants/tool/mittwald-cli/org/membership-revoke-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Revoke Organization Membership',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Revoke a user\'s membership to an organization.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Create Project",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Create a new project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Delete Project",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: "Delete a project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/filesystem-usage-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/filesystem-usage-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get Filesystem Usage",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Get a project directory filesystem usage.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get Project Details",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Get details of a project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/invite-get-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/invite-get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Project Invite Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a project invite.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/invite-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/invite-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Project Invites',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List project invites.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/invite-list-own-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/invite-list-own-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My Project Invites',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List own project invites.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List Projects",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all projects that you have access to.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/membership-get-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/membership-get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Project Membership Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of a project membership.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/membership-get-own-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/membership-get-own-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get My Project Membership',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get details of own project membership.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/membership-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/membership-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Project Members',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List project memberships.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/membership-list-own-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/membership-list-own-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My Project Memberships',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List own project memberships.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/project/ssh-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/ssh-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Get Project SSH Connection Data",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description:
     "Get the SSH connection data (host, user, web root) for a project, plus a ready-to-run ssh command. " +

--- a/src/constants/tool/mittwald-cli/project/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/project/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Update Project",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Update an existing project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/registry/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/registry/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Registry',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new registry in Mittwald.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/registry/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/registry/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Registry',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a registry from Mittwald.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/registry/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/registry/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Registries',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List registries available in Mittwald.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/registry/update-cli.ts
+++ b/src/constants/tool/mittwald-cli/registry/update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Update Registry',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Update an existing registry in Mittwald.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/server/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/server/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Server Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get server details.. Retrieves information about a specific server.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/server/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/server/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Servers',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List servers for an organization or user.. Shows all servers accessible to the current user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/sftp/user-create-cli.ts
+++ b/src/constants/tool/mittwald-cli/sftp/user-create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Create SFTP User",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Create a new SFTP user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/sftp/user-delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/sftp/user-delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Delete SFTP User",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Delete an SFTP user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/sftp/user-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/sftp/user-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List SFTP Users",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all SFTP users for a project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/sftp/user-update-cli.ts
+++ b/src/constants/tool/mittwald-cli/sftp/user-update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Update SFTP User",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Update an existing SFTP user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/ssh/user-create-cli.ts
+++ b/src/constants/tool/mittwald-cli/ssh/user-create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Create SSH User",
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "Create a new SSH user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/ssh/user-delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/ssh/user-delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Delete SSH User",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Delete an SSH user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/ssh/user-list-cli.ts
+++ b/src/constants/tool/mittwald-cli/ssh/user-list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "List SSH Users",
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: "List all SSH users for a project.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/ssh/user-update-cli.ts
+++ b/src/constants/tool/mittwald-cli/ssh/user-update-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: "Update SSH User",
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: "Update an existing SSH user.",
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/stack/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/stack/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Stack',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Delete a stack.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/stack/deploy-cli.ts
+++ b/src/constants/tool/mittwald-cli/stack/deploy-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Deploy Stack',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: true,
   },
   description: 'Deploy a docker-compose YAML configuration to a Mittwald stack. Accepts docker-compose format and converts it to Mittwald\'s native format. IMPORTANT: This is a declarative API - the provided configuration REPLACES the entire stack. Any services or volumes not included will be DELETED. You MUST first read the existing stack configuration (using mittwald_stack_get) before updating, then merge your changes with the existing services/volumes to avoid data loss.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/stack/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/stack/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Stacks',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List stacks for a given project.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/stack/ps-cli.ts
+++ b/src/constants/tool/mittwald-cli/stack/ps-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Stack Services',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all services within a given stack.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/api-token/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/api-token/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create API Token',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new API token.. API tokens can be used to authenticate API requests.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/api-token/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/api-token/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get API Token Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get a specific API token.. Retrieves information about a specific API token.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/api-token/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/api-token/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My API Tokens',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all API tokens of the user.. Shows all API tokens belonging to the current user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/api-token/revoke-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/api-token/revoke-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Revoke API Token',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Revoke an API token.. Permanently disables the specified API token.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get User Profile',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get profile information for a user.. Defaults to the currently authenticated user if no user ID is provided.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/session/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/session/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get Session Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get a specific session.. Retrieves information about a specific user session.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/session/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/session/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My Sessions',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List all active sessions.. Shows all active sessions for the current user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/ssh-key/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/ssh-key/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create SSH Key',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create and import a new SSH key.. Generates a new SSH key pair and imports the public key.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/ssh-key/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/ssh-key/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete SSH Key',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete an SSH key.. Permanently removes the specified SSH key.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/ssh-key/get-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/ssh-key/get-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Get SSH Key Details',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get a specific SSH key.. Retrieves information about a specific SSH key.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/user/ssh-key/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/user/ssh-key/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List My SSH Keys',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Get your stored SSH keys.. Lists all SSH keys for the current user.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/volume/create-cli.ts
+++ b/src/constants/tool/mittwald-cli/volume/create-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Create Volume',
     readOnlyHint: false,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'Create a new named volume inside a project stack.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/volume/delete-cli.ts
+++ b/src/constants/tool/mittwald-cli/volume/delete-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'Delete Volume',
     readOnlyHint: false,
     destructiveHint: true,
+    openWorldHint: false,
   },
   description: 'Delete a persistent volume. WARNING: This permanently removes stored data.',
   inputSchema: {

--- a/src/constants/tool/mittwald-cli/volume/list-cli.ts
+++ b/src/constants/tool/mittwald-cli/volume/list-cli.ts
@@ -9,6 +9,7 @@ const tool: Tool = {
     title: 'List Volumes',
     readOnlyHint: true,
     destructiveHint: false,
+    openWorldHint: false,
   },
   description: 'List persistent volumes that belong to a project stack.',
   inputSchema: {

--- a/tests/unit/tools/tool-annotations.test.ts
+++ b/tests/unit/tools/tool-annotations.test.ts
@@ -4,9 +4,12 @@ import { initializeTools, TOOLS } from '../../../src/constants/tools.js';
 
 /**
  * Every tool exposed to clients must carry a human-readable title and the
- * applicable behavioural hint, as required by the Claude connector review
+ * applicable behavioural hints, as required by the Claude connector review
  * criteria:
  * https://claude.com/docs/connectors/building/review-criteria#provide-tool-annotations
+ *
+ * `openWorldHint` is additionally required for the OpenAI integration: it marks
+ * the write tools that can change publicly visible internet state.
  */
 describe('Tool annotations', () => {
   beforeAll(async () => {
@@ -25,16 +28,25 @@ describe('Tool annotations', () => {
     expect(missing).toEqual([]);
   });
 
-  it('every tool declares readOnlyHint and destructiveHint', () => {
+  it('every tool declares readOnlyHint, destructiveHint and openWorldHint', () => {
     const missing = TOOLS.filter((tool: Tool) => {
       const annotations = tool.annotations;
       return (
         typeof annotations?.readOnlyHint !== 'boolean' ||
-        typeof annotations?.destructiveHint !== 'boolean'
+        typeof annotations?.destructiveHint !== 'boolean' ||
+        typeof annotations?.openWorldHint !== 'boolean'
       );
     }).map((tool) => tool.name);
 
     expect(missing).toEqual([]);
+  });
+
+  it('never marks a read-only tool as open-world', () => {
+    const contradictory = TOOLS.filter(
+      (tool: Tool) => tool.annotations?.readOnlyHint && tool.annotations?.openWorldHint,
+    ).map((tool) => tool.name);
+
+    expect(contradictory).toEqual([]);
   });
 
   it('never marks a tool as both read-only and destructive', () => {


### PR DESCRIPTION
Stacked on #59.

The OpenAI integration requires an `openWorldHint` on every tool: `true` for write tools that can change publicly visible internet state (publishing content, changing what a public site or mail domain serves, pushing code, messaging third parties), `false` for tools that stay within closed or private systems. Read-only tools change nothing, so they are always `false`.

`openWorldHint: true` covers:

- app installs, updates, upgrades, uninstalls and copies — they change what a public site serves
- certificate requests — public CT logs and public TLS
- container and stack operations — they serve public traffic
- cronjob create/update/delete/execute/abort — they run arbitrary code that may reach third parties
- DNS zone and virtualhost changes — public routing state
- mail address create/update/delete — publicly routable addresses
- organisation invitations — they send email to an external recipient
- project deletion — takes the project's public sites offline

Everything else (databases, backups, volumes, registries, SSH/SFTP users, API tokens, memberships, delivery boxes) stays `false`.

`tests/unit/tools/tool-annotations.test.ts` now fails on a missing `openWorldHint`, and additionally rejects a tool marked both read-only and open-world. `CLAUDE.md` documents the rule for new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZDg2TgKTQ5gTY1TpaBMbb