### PR TITLE
fix(tests): correct stale bridge PKCE assertions and run e2e on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: [unit, bridge, session]
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6

--- a/tests/e2e/claude-ai-oauth-flow.test.ts
+++ b/tests/e2e/claude-ai-oauth-flow.test.ts
@@ -316,7 +316,12 @@ describe('Claude.ai OAuth 2.1 End-to-End Flow', () => {
       expect(mittwaldRedirect.pathname).toBe('/oauth/authorize');
       const internalState = mittwaldRedirect.searchParams.get('state');
       expect(internalState).toBeTruthy();
-      expect(mittwaldRedirect.searchParams.get('code_challenge')).toBe(codeChallenge);
+      // The bridge terminates the client's PKCE exchange and originates its own
+      // upstream pair (FR-005), so the challenge sent to Mittwald must NOT be the client's.
+      const upstreamCodeChallenge = mittwaldRedirect.searchParams.get('code_challenge');
+      expect(upstreamCodeChallenge).toBeTruthy();
+      expect(upstreamCodeChallenge).not.toBe(codeChallenge);
+      expect(mittwaldRedirect.searchParams.get('code_challenge_method')).toBe('S256');
 
       if (!internalState) {
         throw new Error('Mittwald redirect missing internal state parameter');
@@ -379,7 +384,13 @@ describe('Claude.ai OAuth 2.1 End-to-End Flow', () => {
       expect(lastTokenRequest).toBeTruthy();
       expect(lastTokenRequest?.body?.grant_type).toBe('authorization_code');
       expect(lastTokenRequest?.body?.code).toBe(mittwaldAuthCode);
-      expect(lastTokenRequest?.body?.code_verifier).toBe(codeVerifier);
+      // The bridge redeems Mittwald's code with its own verifier, which must be the
+      // pre-image of the challenge it sent upstream at /authorize — never the client's.
+      const upstreamCodeVerifier = lastTokenRequest?.body?.code_verifier as string;
+      expect(upstreamCodeVerifier).toBeTruthy();
+      expect(upstreamCodeVerifier).not.toBe(codeVerifier);
+      expect(base64UrlEncode(createHash('sha256').update(upstreamCodeVerifier).digest()))
+        .toBe(upstreamCodeChallenge);
       expect(lastTokenRequest?.body?.redirect_uri).toContain('/mittwald/callback');
 
       const verifiedJwt = await verifyBridgeJwt(tokenBody.access_token);


### PR DESCRIPTION
## Summary

`tests/e2e/claude-ai-oauth-flow.test.ts` was failing on the "Phases 4-8: Local OAuth Flow" case with a mismatch between two random-looking base64url strings. The bridge is fine — the test was stale.

Two assertions expected the `code_challenge`/`code_verifier` the bridge sends **upstream to Mittwald** to be the *client's* values. Since FR-005 (6a4c8af0, 2025-12-03) the bridge deliberately terminates the client's PKCE exchange and originates its own pair for the upstream leg (`packages/oauth-bridge/src/routes/authorize.ts:141-142,182`):

```ts
// Send bridge's challenge to Mittwald (NOT the client's challenge)
mittwaldRedirect.searchParams.set('code_challenge', mittwaldCodeChallenge);
```

The client's challenge is stored separately and only used to verify the client at `/token`. So the values are *supposed* to differ, and the upstream one is freshly random per run — it could never match. The assertions date to 2025-10-04 (d219c5f0), when the bridge did forward the client's challenge verbatim; the follow-up test fix that same day (2c234e9b) touched this file but missed them.

## Changes

- **Line 319** — assert the upstream challenge is present, differs from the client's, and uses `S256`.
- **Line 387** — the second instance, which only surfaced once the first was fixed. Rather than a plain inequality, assert the upstream verifier is the S256 pre-image of the challenge captured at `/authorize`. This ties the two halves of the upstream leg together, so a genuinely broken bridge sending a mismatched verifier still fails.
- **`.github/workflows/tests.yml`** — the `e2e` job already existed but was gated to `schedule`/`workflow_dispatch`; it now also runs on `pull_request`. This gap is why the breakage sat unnoticed from December until now.

Test code only — no production code touched.

## Verification

Full e2e suite locally: **3 files passed, 35 tests passed**. Also checked `all-clients-compatibility.test.ts` and `packages/oauth-bridge/tests/` for the same assumption — these two lines were the only instances.

## Note on the CI change

The e2e job spins up bridge + MCP server + Redis via Docker Compose and is self-contained (no secrets), so it should work on PRs from within the repo. It has a 45-minute timeout and takes ~1-2 min locally. Two things worth a second opinion: it will add runtime to every PR, and if you ever take PRs from forks, `pull_request` runs there have no secret access — not an issue today since the suite doesn't need any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqYEycYEbdG7uEyXrELxei