### PR TITLE
feat: require OPENAI_APPS_CHALLENGE env var, drop hardcoded fallback

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -236,9 +236,12 @@ async function setupUtilityRoutes(app: express.Application): Promise<void> {
   app.use('', oauthMetadataRoutes.getRouter());
 
   // OpenAI Apps domain-verification challenge (ChatGPT app submission)
-  const openaiAppsChallenge =
-    process.env.OPENAI_APPS_CHALLENGE || 'TMjy_Jie1D1d1jHg8zZigHYwG2wRbhMfFgrIqCuoFqY';
+  const openaiAppsChallenge = process.env.OPENAI_APPS_CHALLENGE;
   app.get('/.well-known/openai-apps-challenge', (_, res) => {
+    if (!openaiAppsChallenge) {
+      res.sendStatus(404);
+      return;
+    }
     res.type('text/plain').send(openaiAppsChallenge);
   });
 


### PR DESCRIPTION
## Summary

- The `/.well-known/openai-apps-challenge` route now reads the token **only** from the `OPENAI_APPS_CHALLENGE` env var — the hardcoded fallback is removed.
- When the env var is unset, the route returns `404` instead of serving an empty/default body.

## Note

Production will 404 on this path until `OPENAI_APPS_CHALLENGE` is set on the MCP server container. Terraform wiring in `deploy/` is intentionally **not** part of this PR and needs to be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkeecQ82Lyn8nL5ggpjV9s