### PR TITLE
fix(cli-core): stop leaking raw API errors into tool results

### DIFF
--- a/packages/mittwald-cli-core/src/resources/app-catalog.ts
+++ b/packages/mittwald-cli-core/src/resources/app-catalog.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListAllAppsOptions extends LibraryFunctionBase {}
@@ -22,11 +22,7 @@ export async function listAllApps(options: ListAllAppsOptions): Promise<LibraryR
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -47,11 +43,7 @@ export async function resolveAppNameToUuid(options: ResolveAppNameOptions): Prom
 
     return { data: appUuid, status: 200, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -70,10 +62,6 @@ export async function getAppVersions(options: GetAppVersionsOptions): Promise<Li
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/app-upgrade.ts
+++ b/packages/mittwald-cli-core/src/resources/app-upgrade.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListUpgradeCandidatesOptions extends LibraryFunctionBase {
@@ -29,11 +29,7 @@ export async function listUpgradeCandidates(options: ListUpgradeCandidatesOption
 
     return { data: candidates, status: 200, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -59,10 +55,6 @@ export async function upgradeApp(options: UpgradeAppOptions): Promise<LibraryRes
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/app.ts
+++ b/packages/mittwald-cli-core/src/resources/app.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { LibraryError, libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListAppsOptions extends LibraryFunctionBase {
@@ -34,11 +34,7 @@ export async function listApps(options: ListAppsOptions): Promise<LibraryResult<
 
     return { data: enrichedData, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -71,11 +67,7 @@ export async function getApp(options: GetAppOptions): Promise<LibraryResult<any>
 
     return { data: enriched, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -104,11 +96,7 @@ export async function getProjectIdFromInstallation(
 
     return { data: projectId, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -126,11 +114,7 @@ export async function uninstallApp(options: UninstallAppOptions): Promise<Librar
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -158,11 +142,7 @@ export async function updateApp(options: UpdateAppOptions): Promise<LibraryResul
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -188,10 +168,6 @@ export async function copyApp(options: CopyAppOptions): Promise<LibraryResult<an
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/backup.ts
+++ b/packages/mittwald-cli-core/src/resources/backup.ts
@@ -5,7 +5,7 @@
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
 import { executeApiCall } from './execute-api-call.js';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListBackupsOptions extends LibraryFunctionBase {
@@ -138,11 +138,7 @@ export async function getBackupDownloadUrl(
       durationMs: performance.now() - startTime,
     };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 

--- a/packages/mittwald-cli-core/src/resources/execute-api-call.ts
+++ b/packages/mittwald-cli-core/src/resources/execute-api-call.ts
@@ -5,7 +5,7 @@
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
 import type { LibraryResult } from '../contracts/functions.js';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 
 /**
  * Runs an API call with a token-scoped client, asserts the expected status and
@@ -29,10 +29,6 @@ export async function executeApiCall<T = any>(
       durationMs: performance.now() - startTime,
     };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/project.ts
+++ b/packages/mittwald-cli-core/src/resources/project.ts
@@ -5,7 +5,7 @@
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 
 export interface ListProjectsOptions extends LibraryFunctionBase {
   serverId?: string;
@@ -21,11 +21,7 @@ export async function listProjects(options: ListProjectsOptions): Promise<Librar
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -43,11 +39,7 @@ export async function getProject(options: GetProjectOptions): Promise<LibraryRes
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -70,11 +62,7 @@ export async function createProject(options: CreateProjectOptions): Promise<Libr
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -97,11 +85,7 @@ export async function updateProject(options: UpdateProjectOptions): Promise<Libr
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -119,11 +103,7 @@ export async function deleteProject(options: DeleteProjectOptions): Promise<Libr
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -142,11 +122,7 @@ export async function listProjectMemberships(options: ListProjectMembershipsOpti
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -164,11 +140,7 @@ export async function getProjectMembership(options: GetProjectMembershipOptions)
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -187,11 +159,7 @@ export async function listProjectInvites(options: ListProjectInvitesOptions): Pr
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -209,10 +177,6 @@ export async function getProjectInvite(options: GetProjectInviteOptions): Promis
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/user-api-token.ts
+++ b/packages/mittwald-cli-core/src/resources/user-api-token.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListUserApiTokensOptions extends LibraryFunctionBase {
@@ -21,11 +21,7 @@ export async function listUserApiTokens(options: ListUserApiTokensOptions): Prom
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -43,11 +39,7 @@ export async function getUserApiToken(options: GetUserApiTokenOptions): Promise<
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -73,11 +65,7 @@ export async function createUserApiToken(options: CreateUserApiTokenOptions): Pr
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -95,10 +83,6 @@ export async function revokeUserApiToken(options: RevokeUserApiTokenOptions): Pr
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/user-session.ts
+++ b/packages/mittwald-cli-core/src/resources/user-session.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListUserSessionsOptions extends LibraryFunctionBase {
@@ -21,11 +21,7 @@ export async function listUserSessions(options: ListUserSessionsOptions): Promis
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -43,10 +39,6 @@ export async function getUserSession(options: GetUserSessionOptions): Promise<Li
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/user-ssh-key.ts
+++ b/packages/mittwald-cli-core/src/resources/user-ssh-key.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface ListUserSshKeysOptions extends LibraryFunctionBase {
@@ -21,11 +21,7 @@ export async function listUserSshKeys(options: ListUserSshKeysOptions): Promise<
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -43,11 +39,7 @@ export async function getUserSshKey(options: GetUserSshKeyOptions): Promise<Libr
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -72,11 +64,7 @@ export async function createUserSshKey(options: CreateUserSshKeyOptions): Promis
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }
 
@@ -94,10 +82,6 @@ export async function deleteUserSshKey(options: DeleteUserSshKeyOptions): Promis
 
     return { data: undefined, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/packages/mittwald-cli-core/src/resources/user.ts
+++ b/packages/mittwald-cli-core/src/resources/user.ts
@@ -4,7 +4,7 @@
 
 import { MittwaldAPIV2Client } from '@mittwald/api-client';
 import { assertStatus } from '@mittwald/api-client-commons';
-import { LibraryError } from '../contracts/functions.js';
+import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 
 export interface GetUserOptions extends LibraryFunctionBase {
@@ -22,10 +22,6 @@ export async function getUser(options: GetUserOptions): Promise<LibraryResult<an
 
     return { data: response.data, status: response.status, durationMs: performance.now() - startTime };
   } catch (error) {
-    throw new LibraryError(
-      error instanceof Error ? error.message : 'Unknown error',
-      (error as any).status || 500,
-      { originalError: error, durationMs: performance.now() - startTime }
-    );
+    throw libraryErrorFromApiError(error, startTime);
   }
 }

--- a/tests/security/credential-leakage.test.ts
+++ b/tests/security/credential-leakage.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { redactCredentialsFromCommand } from '../../src/utils/credential-redactor.js';
 import { buildUpdatedAttributes } from '../../src/utils/credential-response.js';
+import { formatToolResponse } from '../../src/utils/format-tool-response.js';
+import { LibraryError, libraryErrorFromApiError } from '../../packages/mittwald-cli-core/src/contracts/functions.js';
 
 describe('Credential Security Validation', () => {
   describe('Command Redaction', () => {
@@ -32,6 +34,87 @@ describe('Credential Security Validation', () => {
       expect(safe).not.toContain('pw123');
       expect(safe).not.toContain('tk456');
       expect(safe).toContain('[REDACTED]');
+    });
+  });
+
+  describe('API Error Sanitization', () => {
+    const SECRET_TOKEN = '79d04ed5-live-mittwald-access-token';
+
+    /**
+     * Shaped like a real axios error: the sensitive data (the access token) lives on
+     * `config.headers`, not on `response.data`, and is only reachable through the
+     * `toJSON()` method that axios attaches to `AxiosError.prototype`. `JSON.stringify`
+     * calls `toJSON()` automatically, so any code path that serializes the raw error
+     * object (e.g. `{ details: { originalError: error } }`) reintroduces the leak even
+     * though naive string/property inspection of the error looks safe.
+     */
+    function fakeAxiosError() {
+      const config = {
+        url: 'https://api.mittwald.de/v2/projects/abc/memberships',
+        method: 'get',
+        headers: {
+          'x-access-token': SECRET_TOKEN,
+          Accept: 'application/json',
+        },
+      };
+      const response = {
+        status: 403,
+        statusText: 'Forbidden',
+        data: {
+          type: 'AuthorizationError',
+          message: 'You are not allowed to perform this action.',
+          params: { traceId: 'trace-abc-123' },
+        },
+      };
+
+      return {
+        isAxiosError: true,
+        name: 'AxiosError',
+        message: 'Request failed with status code 403',
+        code: 'ERR_BAD_REQUEST',
+        config,
+        request: {},
+        response,
+        stack: 'AxiosError: Request failed with status code 403\n    at /home/agent/app/node_modules/axios/lib/core/settle.js:19:12',
+        toJSON() {
+          return {
+            message: this.message,
+            name: this.name,
+            stack: this.stack,
+            config,
+            code: this.code,
+            status: response.status,
+          };
+        },
+      };
+    }
+
+    it('strips request config, headers and stack traces from LibraryError.details', () => {
+      const error = libraryErrorFromApiError(fakeAxiosError(), performance.now());
+
+      expect(error).toBeInstanceOf(LibraryError);
+      expect(JSON.stringify(error.details)).not.toContain(SECRET_TOKEN);
+      expect(error.details).not.toHaveProperty('originalError');
+      expect(error.details).not.toHaveProperty('config');
+      expect(error.details).not.toHaveProperty('headers');
+      expect(error.details).not.toHaveProperty('stack');
+
+      // still carries the information handlers/users actually need
+      expect((error.details as Record<string, unknown>).status).toBe(403);
+      expect((error.details as Record<string, unknown>).traceId).toBe('trace-abc-123');
+    });
+
+    it('never leaks the live access token through a tool error response', () => {
+      const error = libraryErrorFromApiError(fakeAxiosError(), performance.now());
+      const toolResult = formatToolResponse('error', error.message, {
+        code: error.code,
+        details: error.details,
+      });
+
+      const text = (toolResult.content[0] as { text: string }).text;
+      expect(text).not.toContain(SECRET_TOKEN);
+      expect(text).not.toContain('x-access-token');
+      expect(text).not.toContain('/home/agent');
     });
   });
 


### PR DESCRIPTION
## Summary
- A live Mittwald API access token (and internal stack traces / file paths) was being leaked into MCP tool results on ordinary API errors (e.g. a 403 from a Member-role account calling project membership/invite endpoints).
- Root cause: several `packages/mittwald-cli-core/src/resources/*.ts` functions (`project`, `app`, `app-catalog`, `app-upgrade`, `user`, `user-session`, `user-api-token`, `user-ssh-key`, `backup`, `execute-api-call`) wrapped failed API calls as `new LibraryError(msg, status, { originalError: error, ... })`. Handlers forward `LibraryError.details` verbatim into the JSON tool response via `formatToolResponse`, which calls `JSON.stringify`. Axios's `AxiosError.prototype.toJSON()` is auto-invoked by `JSON.stringify`, serializing the full request `config` — including the `x-access-token` header carrying the live session token — plus the error's stack trace.
- Confirmed reproducible on `mittwald_project_membership_list`, `mittwald_project_invite_list`, `mittwald_project_membership_get`, `mittwald_app_get`, and `mittwald_project_delete`.
- `database-mysql.ts` was already safe: it uses `libraryErrorFromApiError()`, which extracts only `status`, `statusText`, `type`, `validationErrors`, and `traceId` — no raw error, headers, or stack. This PR routes all 10 affected files through that same helper (33 call sites total).
- Already deployed via `v0.4.4-beta1` (tag pushed directly for hotfix urgency); this PR is to get the change merged into `main` and reviewed.

## Test plan
- [x] Added a regression test to `tests/security/credential-leakage.test.ts` using a realistic `AxiosError` shape (token only reachable via `toJSON()`, matching real axios behavior). Verified it fails against the old vulnerable pattern (reproduces the token/header/stack-trace leak) and passes with the fix.
- [x] `npx vitest run tests/unit tests/security` — 424/424 tests passing
- [x] `npx eslint` on all touched files — clean
- [x] `npx tsc --noEmit` on the main server project — clean (pre-existing, unrelated build errors remain in vendored `src/lib`/`src/rendering` legacy CLI code under `packages/mittwald-cli-core`, confirmed present on `main` before this change too)

**Note:** the token exposed during the original review (`79d04ed5-...`) should be treated as burned and rotated if that hasn't happened already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)