### PR TITLE
docs: remove Support Tickets example from GitHub Copilot guide

### DIFF
--- a/docs/setup-and-guides/src/content/docs/getting-connected/github-copilot.md
+++ b/docs/setup-and-guides/src/content/docs/getting-connected/github-copilot.md
@@ -133,12 +133,6 @@ Get database connection info for [db-id]
 Check backup schedules for project [project-id]
 ```
 
-### Support Tickets
-
-```
-List open support conversations for my account
-```
-
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Removes the "### Support Tickets" example prompt ("List open support conversations for my account") from `docs/setup-and-guides/src/content/docs/getting-connected/github-copilot.md`.
- The prompt implies `mittwald_conversation_list` is a usable capability. It is not: every `mittwald_conversation_*` tool (`categories`, `close`, `create`, `list`, `reply`, `show`) is excluded from the tool registry in `src/utils/tool-scanner.ts` (`EXCLUDED_TOOLS_WITH_REASONS`) because the underlying Mittwald API endpoints return HTTP 403 for any OAuth token — Mittwald does not publish a conversation scope. This is already documented as a permanent limitation with no workaround in `docs/KNOWN-LIMITATIONS.md` under "No API Support (3 tools)".
- Flagged in code review as a low-severity listing-accuracy issue: "Support - open and reply to support conversations" describes a capability with no working tool behind it.

## Investigation

Searched the whole repo and both docs sites (`docs/setup-and-guides`, `docs/reference`) for other user-facing references to support/conversation functionality:
- `docs/reference/` never generated a tool page for `conversation` tools (0 tools registered, `toolCount: 0` for that domain in `tools-manifest.json`) — already correct, no change needed.
- `docs/chatgpt-app-submission.json` does not list any `conversation_*` tools — already correct, no change needed.
- The other getting-connected guides (`cursor.md`, `claude-code.md`, `codex-cli.md`) and everything under `how-to/`, `tutorials/`, `runbooks/`, `index.md` have no equivalent example — `github-copilot.md` was the only user-facing spot presenting this as a working capability.
- `docs/mittwald-cli-coverage.md` marks `conversation list`/`conversation reply` as "✅ Covered" (meaning a tool definition exists in code), but that's an internal coverage-tracking doc, not end-user guidance, and it's consistent with the established context that these tools exist in code but are excluded at runtime — left unchanged as out of scope.

## Test plan

- [x] `npm run docs:guardrails` passes (internal links, Codex CLI flag validation, tutorial→use-case mappings)
- [x] `docs/setup-and-guides` (`npm run build`) builds cleanly with no broken links or errors
- [x] Manually reviewed surrounding markdown — heading levels and `---` separators still read cleanly after the removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)