### PR TITLE
fix: mark stackId and projectId as required in mittwald_stack_ps schema

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -10528,7 +10528,11 @@
                     "type": "string",
                     "description": "ID of the project containing the stack"
                   }
-                }
+                },
+                "required": [
+                  "stackId",
+                  "projectId"
+                ]
               }
             }
           }

--- a/docs/reference/src/content/docs/tools/stack/stack-ps.md
+++ b/docs/reference/src/content/docs/tools/stack/stack-ps.md
@@ -13,7 +13,7 @@ head:
     attrs:
       name: og:description
       content: "List all services within a given stack."
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-11
 ---
 ## Overview
 
@@ -23,8 +23,8 @@ List all services within a given stack.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `stackId` | `string` | No | ID of a stack |
-| `projectId` | `string` | No | ID of the project containing the stack |
+| `stackId` | `string` | Yes | ID of a stack |
+| `projectId` | `string` | Yes | ID of the project containing the stack |
 
 ## Return Type
 

--- a/docs/reference/tools-manifest.json
+++ b/docs/reference/tools-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-23T09:50:41.108Z",
+  "generatedAt": "2026-08-11T09:30:54.506Z",
   "totalTools": 116,
   "tools": {
     "app": [
@@ -4761,13 +4761,13 @@
             "name": "stackId",
             "type": "string",
             "description": "ID of a stack",
-            "required": false
+            "required": true
           },
           {
             "name": "projectId",
             "type": "string",
             "description": "ID of the project containing the stack",
-            "required": false
+            "required": true
           }
         ],
         "returnType": {

--- a/src/constants/tool/mittwald-cli/stack/ps-cli.ts
+++ b/src/constants/tool/mittwald-cli/stack/ps-cli.ts
@@ -24,7 +24,7 @@ const tool: Tool = {
         description: 'ID of the project containing the stack'
       }
     },
-    required: []
+    required: ['stackId', 'projectId']
   }
 };
 


### PR DESCRIPTION
## Summary

`mittwald_stack_ps`'s JSON schema listed `required: []`, but its handler (`handleStackPsCli` in
`src/handlers/tools/mittwald-cli/stack/ps-cli.ts`) explicitly checks `if (!args.stackId)` and
`if (!args.projectId)` and returns an error response for either before doing anything else. So at
runtime both parameters are mandatory, but the schema gave callers no way to know that.

This was flagged in code review as a low-severity schema accuracy issue.

## Changes

- `src/constants/tool/mittwald-cli/stack/ps-cli.ts`: set `inputSchema.required` to
  `['stackId', 'projectId']`, matching the handler's actual runtime requirements.
- Regenerated the tool reference docs (`npm run docs:generate`) so `docs/reference/tools-manifest.json`,
  `docs/reference/openapi.json`, and the `mittwald_stack_ps` reference page reflect the corrected
  schema. `mw-cli-coverage.json` / `docs/mittwald-cli-coverage.md` do not embed parameter schema
  data, so no change was needed there (confirmed by re-running `generate-mw-coverage.ts`, which
  produced no diff).

## Test plan

- [x] `npm run build:all`
- [x] `npm run type-check`
- [x] `npm run lint` (no new issues; pre-existing lint errors on `main` are unchanged and unrelated to this fix)
- [x] `npm run test:unit` (357 tests passed, including `tests/unit/tools/tool-annotations.test.ts`)
- [x] `npm run docs:guardrails`
- [x] Verified no test or script asserts on the old `required: []` for this tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)