### PR TITLE
fix: resolve real MySQL username on database create

### DIFF
--- a/packages/mittwald-cli-core/src/lib/poll.test.ts
+++ b/packages/mittwald-cli-core/src/lib/poll.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { poll, PollTimeoutError } from './poll.js';
+
+describe('poll', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves immediately when the first attempt is already ready', async () => {
+    const fn = vi.fn().mockResolvedValue('ready-value');
+
+    const result = await poll(fn, (value) => value === 'ready-value');
+
+    expect(result).toBe('ready-value');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until a later attempt is ready', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockResolvedValueOnce('not-ready').mockResolvedValueOnce('not-ready').mockResolvedValueOnce('ready');
+
+    const resultPromise = poll(fn, (value) => value === 'ready', { maxAttempts: 5 });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toBe('ready');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('applies exponential backoff between attempts', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockResolvedValue('not-ready');
+    const delayFn = vi.fn((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+    const resultPromise = poll(fn, (value) => value === 'ready', {
+      maxAttempts: 4,
+      initialDelayMs: 100,
+      backoffFactor: 2,
+      delayFn,
+    });
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    // 4 attempts -> 3 delays between them, doubling from the initial delay.
+    expect(delayFn.mock.calls.map(([ms]) => ms)).toEqual([100, 200, 400]);
+  });
+
+  it('caps the delay at maxDelayMs', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockResolvedValue('not-ready');
+    const delayFn = vi.fn((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+    const resultPromise = poll(fn, (value) => value === 'ready', {
+      maxAttempts: 5,
+      initialDelayMs: 100,
+      backoffFactor: 3,
+      maxDelayMs: 250,
+      delayFn,
+    });
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    expect(delayFn.mock.calls.map(([ms]) => ms)).toEqual([100, 250, 250, 250]);
+  });
+
+  it('resolves with undefined once the attempt budget is exhausted by default', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockResolvedValue('never-ready');
+
+    const resultPromise = poll(fn, (value) => value === 'ready', { maxAttempts: 3 });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toBeUndefined();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws PollTimeoutError once the attempt budget is exhausted when throwOnExhausted is set', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockResolvedValue('never-ready');
+
+    const resultPromise = poll(fn, (value) => value === 'ready', {
+      maxAttempts: 3,
+      throwOnExhausted: true,
+    });
+    const assertion = expect(resultPromise).rejects.toBeInstanceOf(PollTimeoutError);
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it('propagates an error from fn immediately by default (retryOnError: false)', async () => {
+    const error = new Error('boom');
+    const fn = vi.fn().mockRejectedValue(error);
+
+    await expect(poll(fn, () => true)).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps retrying past an error from fn when retryOnError is true', async () => {
+    vi.useFakeTimers();
+
+    const fn = vi.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('ready');
+
+    const resultPromise = poll(fn, (value) => value === 'ready', {
+      maxAttempts: 3,
+      retryOnError: true,
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toBe('ready');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mittwald-cli-core/src/lib/poll.ts
+++ b/packages/mittwald-cli-core/src/lib/poll.ts
@@ -1,0 +1,106 @@
+/**
+ * Generic polling helper for reading a value repeatedly until it looks "ready", with
+ * exponential backoff between attempts.
+ *
+ * Typical use case in this codebase: right after creating a resource via the Mittwald API,
+ * a follow-up read of the same resource can briefly return incomplete data because the backend
+ * hasn't converged yet (eventual consistency). `poll` re-issues that read a bounded number of
+ * times, waiting a little longer between each attempt, until either the data looks ready or the
+ * attempt budget is exhausted.
+ */
+
+export interface PollOptions {
+  /** Maximum number of attempts (including the first). Default: 5. */
+  maxAttempts?: number;
+  /** Delay before the second attempt, in ms. Grows by `backoffFactor` after that. Default: 100. */
+  initialDelayMs?: number;
+  /** Multiplier applied to the delay after each attempt. Default: 2. */
+  backoffFactor?: number;
+  /** Upper bound for any single delay, in ms. Default: 5000. */
+  maxDelayMs?: number;
+  /**
+   * If `fn()` throws, should `poll` treat that attempt as "not ready" and keep going (`true`),
+   * or propagate the error immediately (`false`)? Default: `false` — errors are unexpected by
+   * default, so they surface rather than being silently retried; callers polling for eventual
+   * consistency on an endpoint that itself may transiently error should opt in explicitly.
+   */
+  retryOnError?: boolean;
+  /**
+   * Injectable delay function, primarily so tests can run with fake timers instead of sleeping
+   * for real wall-clock time. Defaults to a real `setTimeout`-based sleep.
+   */
+  delayFn?: (ms: number) => Promise<void>;
+}
+
+/** Thrown by `poll` when `throwOnExhausted` is set and the attempt budget runs out. */
+export class PollTimeoutError extends Error {
+  constructor(attempts: number) {
+    super(`condition was not met after ${attempts} attempt(s)`);
+    this.name = 'PollTimeoutError';
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollImpl<T>(
+  fn: () => Promise<T>,
+  isReady: (result: T) => boolean,
+  options: PollOptions & { throwOnExhausted?: boolean } = {}
+): Promise<T | undefined> {
+  const {
+    maxAttempts = 5,
+    initialDelayMs = 100,
+    backoffFactor = 2,
+    maxDelayMs = 5000,
+    retryOnError = false,
+    throwOnExhausted = false,
+    delayFn = defaultDelay,
+  } = options;
+
+  let delayMs = initialDelayMs;
+  let attempts = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    attempts = attempt;
+
+    if (attempt > 1) {
+      await delayFn(Math.min(delayMs, maxDelayMs));
+      delayMs = Math.min(delayMs * backoffFactor, maxDelayMs);
+    }
+
+    try {
+      const result = await fn();
+      if (isReady(result)) {
+        return result;
+      }
+    } catch (error) {
+      if (!retryOnError) {
+        throw error;
+      }
+      // Best-effort: swallow this attempt's error and try again on the next iteration.
+    }
+  }
+
+  if (throwOnExhausted) {
+    throw new PollTimeoutError(attempts);
+  }
+
+  return undefined;
+}
+
+/**
+ * Calls `fn()` up to `maxAttempts` times, waiting with exponential backoff between attempts,
+ * until `isReady` returns `true` for the resolved value. Resolves with the first "ready" value,
+ * or — once the attempt budget is exhausted — either resolves with `undefined` (default) or
+ * throws a `PollTimeoutError`, depending on `throwOnExhausted`.
+ *
+ * Declared as a single `const` with an overloaded call signature (rather than multiple
+ * `function poll(...)` declarations) so plain ESLint's `no-redeclare` rule — which doesn't
+ * understand TypeScript overload syntax — doesn't flag it.
+ */
+export const poll = pollImpl as {
+  <T>(fn: () => Promise<T>, isReady: (result: T) => boolean, options: PollOptions & { throwOnExhausted: true }): Promise<T>;
+  <T>(fn: () => Promise<T>, isReady: (result: T) => boolean, options?: PollOptions & { throwOnExhausted?: false }): Promise<T | undefined>;
+};

--- a/packages/mittwald-cli-core/src/lib/wait.ts
+++ b/packages/mittwald-cli-core/src/lib/wait.ts
@@ -1,6 +1,7 @@
 import { Flags } from "@oclif/core";
 import Duration from "./units/Duration.js";
 import { InferredFlags } from "@oclif/core/interfaces";
+import { poll } from "./poll.js";
 
 export const waitFlags = {
   wait: Flags.boolean({
@@ -16,22 +17,32 @@ export const waitFlags = {
 
 export type WaitFlags = InferredFlags<typeof waitFlags>;
 
+const WAIT_UNTIL_POLL_INTERVAL_MS = 1000;
+
+/**
+ * Polls `tester` on a fixed ~1s cadence (a thin, CLI-flag-friendly wrapper around the generic
+ * `poll` helper in `./poll.js`) until it returns a truthy value, or throws once `timeout` has
+ * elapsed. Used by CLI commands that offer a `--wait` flag (see `waitFlags` above).
+ */
 export async function waitUntil<T>(
   tester: () => Promise<T | null>,
   timeout = Duration.fromSeconds(600),
 ): Promise<T> {
-  let waited = Duration.fromZero();
-  while (waited.compare(timeout) < 0) {
-    const result = await tester();
-    if (result) {
-      return result;
-    }
+  const maxAttempts = Math.max(1, Math.ceil(timeout.milliseconds / WAIT_UNTIL_POLL_INTERVAL_MS) + 1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    waited = waited.add(Duration.fromSeconds(1));
+  const result = await poll<T | null>(tester, (value) => Boolean(value), {
+    maxAttempts,
+    initialDelayMs: WAIT_UNTIL_POLL_INTERVAL_MS,
+    backoffFactor: 1,
+    maxDelayMs: WAIT_UNTIL_POLL_INTERVAL_MS,
+    retryOnError: false,
+  });
+
+  if (!result) {
+    throw new Error(
+      `expected condition was not reached after ${timeout.toString()}`,
+    );
   }
 
-  throw new Error(
-    `expected condition was not reached after ${timeout.toString()}`,
-  );
+  return result;
 }

--- a/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
@@ -38,7 +38,10 @@ const dbDetails = (overrides: Record<string, unknown> = {}) => ({
 
 describe('createMysqlDatabase', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (rather than clearAllMocks) also drops any not-yet-consumed
+    // mockResolvedValueOnce/mockRejectedValueOnce queue entries, so a test that fails before
+    // fully draining its queued responses can't leak them into the next test.
+    vi.resetAllMocks();
   });
 
   afterEach(() => {
@@ -62,7 +65,7 @@ describe('createMysqlDatabase', () => {
     expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(1);
   });
 
-  it('polls the same getMysqlDatabase endpoint until mainUser.name appears on a later attempt', async () => {
+  it('polls the same getMysqlDatabase endpoint with exponential backoff until mainUser.name appears', async () => {
     vi.useFakeTimers();
 
     mockCreateMysqlDatabase.mockResolvedValue({
@@ -70,19 +73,30 @@ describe('createMysqlDatabase', () => {
       data: { id: 'db-1', userId: 'user-1' },
     });
     mockGetMysqlDatabase
-      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // initial read: not yet populated
-      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // poll attempt 1: still not populated
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // initial read (outside poll): not yet populated
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // poll's 1st attempt (no delay before it): still not populated
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // poll's 2nd attempt (after 100ms): still not populated
       .mockResolvedValueOnce({
         status: 200,
         data: dbDetails({ mainUser: { name: 'dbu_resolved_later' } }),
-      }); // poll attempt 2: now populated
+      }); // poll's 3rd attempt (after another 200ms, doubled): now populated
 
     const resultPromise = createMysqlDatabase(baseOptions);
-    await vi.runAllTimersAsync();
-    const result = await resultPromise;
 
-    expect(result.data.userName).toBe('dbu_resolved_later');
+    // The initial read and poll's first attempt both happen with no delay in front of them.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(2);
+
+    // Poll's second attempt fires after the configured initial delay (100ms).
+    await vi.advanceTimersByTimeAsync(100);
     expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(3);
+
+    // Poll's third attempt fires after the delay has doubled (100ms -> 200ms).
+    await vi.advanceTimersByTimeAsync(200);
+    expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(4);
+
+    const result = await resultPromise;
+    expect(result.data.userName).toBe('dbu_resolved_later');
   });
 
   it('falls back to an empty string without throwing once the poll budget is exhausted', async () => {
@@ -100,7 +114,8 @@ describe('createMysqlDatabase', () => {
     const result = await resultPromise;
 
     expect(result.data.userName).toBe('');
-    // 1 initial read + up to 4 poll attempts = 5 total calls, then it gives up.
+    // 1 initial read + up to MYSQL_USERNAME_POLL_MAX_ATTEMPTS (4) poll attempts = 5 total calls,
+    // then it gives up rather than hanging indefinitely.
     expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(5);
   });
 

--- a/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
@@ -1,8 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCreateMysqlDatabase = vi.fn();
 const mockGetMysqlDatabase = vi.fn();
-const mockListMysqlUsers = vi.fn();
 
 vi.mock('@mittwald/api-client', () => ({
   MittwaldAPIV2Client: {
@@ -10,7 +9,6 @@ vi.mock('@mittwald/api-client', () => ({
       database: {
         createMysqlDatabase: mockCreateMysqlDatabase,
         getMysqlDatabase: mockGetMysqlDatabase,
-        listMysqlUsers: mockListMysqlUsers,
       },
     })),
   },
@@ -29,115 +27,119 @@ const baseOptions = {
   version: '8.0',
 };
 
+const dbDetails = (overrides: Record<string, unknown> = {}) => ({
+  id: 'db-1',
+  name: 'db-1',
+  hostname: 'db-1.mysql.mittwald.de',
+  externalHostname: 'ext-db-1.mysql.mittwald.de',
+  mainUser: undefined,
+  ...overrides,
+});
+
 describe('createMysqlDatabase', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('resolves the real username via listMysqlUsers when mainUser is not yet populated on the fresh database', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses mainUser.name directly when the initial getMysqlDatabase call already has it populated', async () => {
     mockCreateMysqlDatabase.mockResolvedValue({
       status: 201,
       data: { id: 'db-1', userId: 'user-1' },
     });
-
-    // Immediately after creation, the API has not yet populated the mainUser relation.
     mockGetMysqlDatabase.mockResolvedValue({
       status: 200,
-      data: {
-        id: 'db-1',
-        name: 'db-1',
-        hostname: 'db-1.mysql.mittwald.de',
-        externalHostname: 'ext-db-1.mysql.mittwald.de',
-        mainUser: undefined,
-      },
-    });
-
-    mockListMysqlUsers.mockResolvedValue({
-      status: 200,
-      data: [
-        { id: 'user-1', name: 'dbu_abc123', mainUser: true },
-        { id: 'user-2', name: 'dbu_other', mainUser: false },
-      ],
-    });
-
-    const result = await createMysqlDatabase(baseOptions);
-
-    expect(result.data.userName).toBe('dbu_abc123');
-    expect(mockListMysqlUsers).toHaveBeenCalledWith(
-      expect.objectContaining({ mysqlDatabaseId: 'db-1' })
-    );
-  });
-
-  it('uses mainUser.name directly when the database details already have it populated', async () => {
-    mockCreateMysqlDatabase.mockResolvedValue({
-      status: 201,
-      data: { id: 'db-2', userId: 'user-2' },
-    });
-
-    mockGetMysqlDatabase.mockResolvedValue({
-      status: 200,
-      data: {
-        id: 'db-2',
-        name: 'db-2',
-        hostname: 'db-2.mysql.mittwald.de',
-        externalHostname: 'ext-db-2.mysql.mittwald.de',
-        mainUser: { name: 'dbu_already_there' },
-      },
+      data: dbDetails({ mainUser: { name: 'dbu_already_there' } }),
     });
 
     const result = await createMysqlDatabase(baseOptions);
 
     expect(result.data.userName).toBe('dbu_already_there');
-    expect(mockListMysqlUsers).not.toHaveBeenCalled();
+    // Only the initial read — no polling needed once the field is already populated.
+    expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to an empty string when the follow-up listMysqlUsers lookup cannot find a matching user', async () => {
+  it('polls the same getMysqlDatabase endpoint until mainUser.name appears on a later attempt', async () => {
+    vi.useFakeTimers();
+
     mockCreateMysqlDatabase.mockResolvedValue({
       status: 201,
-      data: { id: 'db-3', userId: 'user-3' },
+      data: { id: 'db-1', userId: 'user-1' },
     });
+    mockGetMysqlDatabase
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // initial read: not yet populated
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // poll attempt 1: still not populated
+      .mockResolvedValueOnce({
+        status: 200,
+        data: dbDetails({ mainUser: { name: 'dbu_resolved_later' } }),
+      }); // poll attempt 2: now populated
 
-    mockGetMysqlDatabase.mockResolvedValue({
-      status: 200,
-      data: {
-        id: 'db-3',
-        name: 'db-3',
-        hostname: 'db-3.mysql.mittwald.de',
-        externalHostname: 'ext-db-3.mysql.mittwald.de',
-        mainUser: undefined,
-      },
+    const resultPromise = createMysqlDatabase(baseOptions);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.data.userName).toBe('dbu_resolved_later');
+    expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to an empty string without throwing once the poll budget is exhausted', async () => {
+    vi.useFakeTimers();
+
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-1', userId: 'user-1' },
     });
+    // mainUser never shows up on any attempt.
+    mockGetMysqlDatabase.mockResolvedValue({ status: 200, data: dbDetails() });
 
-    mockListMysqlUsers.mockResolvedValue({
-      status: 200,
-      data: [],
-    });
-
-    const result = await createMysqlDatabase(baseOptions);
+    const resultPromise = createMysqlDatabase(baseOptions);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
 
     expect(result.data.userName).toBe('');
+    // 1 initial read + up to 4 poll attempts = 5 total calls, then it gives up.
+    expect(mockGetMysqlDatabase).toHaveBeenCalledTimes(5);
   });
 
-  it('falls back to an empty string without throwing when the follow-up listMysqlUsers call itself fails', async () => {
+  it('keeps polling past a transient error on an individual poll attempt and still resolves the username', async () => {
+    vi.useFakeTimers();
+
     mockCreateMysqlDatabase.mockResolvedValue({
       status: 201,
-      data: { id: 'db-4', userId: 'user-4' },
+      data: { id: 'db-1', userId: 'user-1' },
     });
+    mockGetMysqlDatabase
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // initial read: not yet populated
+      .mockRejectedValueOnce(new Error('transient network error')) // poll attempt 1: fails
+      .mockResolvedValueOnce({
+        status: 200,
+        data: dbDetails({ mainUser: { name: 'dbu_after_retry' } }),
+      }); // poll attempt 2: succeeds
 
-    mockGetMysqlDatabase.mockResolvedValue({
-      status: 200,
-      data: {
-        id: 'db-4',
-        name: 'db-4',
-        hostname: 'db-4.mysql.mittwald.de',
-        externalHostname: 'ext-db-4.mysql.mittwald.de',
-        mainUser: undefined,
-      },
+    const resultPromise = createMysqlDatabase(baseOptions);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.data.userName).toBe('dbu_after_retry');
+  });
+
+  it('falls back to an empty string without throwing when every poll attempt errors', async () => {
+    vi.useFakeTimers();
+
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-1', userId: 'user-1' },
     });
+    mockGetMysqlDatabase
+      .mockResolvedValueOnce({ status: 200, data: dbDetails() }) // initial read: not yet populated
+      .mockRejectedValue(new Error('backend unavailable')); // every poll attempt fails
 
-    mockListMysqlUsers.mockRejectedValue(new Error('network error'));
-
-    const result = await createMysqlDatabase(baseOptions);
+    const resultPromise = createMysqlDatabase(baseOptions);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
 
     expect(result.data.userName).toBe('');
   });

--- a/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateMysqlDatabase = vi.fn();
+const mockGetMysqlDatabase = vi.fn();
+const mockListMysqlUsers = vi.fn();
+
+vi.mock('@mittwald/api-client', () => ({
+  MittwaldAPIV2Client: {
+    newWithToken: vi.fn(() => ({
+      database: {
+        createMysqlDatabase: mockCreateMysqlDatabase,
+        getMysqlDatabase: mockGetMysqlDatabase,
+        listMysqlUsers: mockListMysqlUsers,
+      },
+    })),
+  },
+}));
+
+vi.mock('@mittwald/api-client-commons', () => ({
+  assertStatus: vi.fn(),
+}));
+
+const { createMysqlDatabase } = await import('./database-mysql.js');
+
+const baseOptions = {
+  apiToken: 'test-token',
+  projectId: 'project-1',
+  description: 'test database',
+  version: '8.0',
+};
+
+describe('createMysqlDatabase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves the real username via listMysqlUsers when mainUser is not yet populated on the fresh database', async () => {
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-1', userId: 'user-1' },
+    });
+
+    // Immediately after creation, the API has not yet populated the mainUser relation.
+    mockGetMysqlDatabase.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 'db-1',
+        name: 'db-1',
+        hostname: 'db-1.mysql.mittwald.de',
+        externalHostname: 'ext-db-1.mysql.mittwald.de',
+        mainUser: undefined,
+      },
+    });
+
+    mockListMysqlUsers.mockResolvedValue({
+      status: 200,
+      data: [
+        { id: 'user-1', name: 'dbu_abc123', mainUser: true },
+        { id: 'user-2', name: 'dbu_other', mainUser: false },
+      ],
+    });
+
+    const result = await createMysqlDatabase(baseOptions);
+
+    expect(result.data.userName).toBe('dbu_abc123');
+    expect(mockListMysqlUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ mysqlDatabaseId: 'db-1' })
+    );
+  });
+
+  it('uses mainUser.name directly when the database details already have it populated', async () => {
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-2', userId: 'user-2' },
+    });
+
+    mockGetMysqlDatabase.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 'db-2',
+        name: 'db-2',
+        hostname: 'db-2.mysql.mittwald.de',
+        externalHostname: 'ext-db-2.mysql.mittwald.de',
+        mainUser: { name: 'dbu_already_there' },
+      },
+    });
+
+    const result = await createMysqlDatabase(baseOptions);
+
+    expect(result.data.userName).toBe('dbu_already_there');
+    expect(mockListMysqlUsers).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an empty string when the follow-up listMysqlUsers lookup cannot find a matching user', async () => {
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-3', userId: 'user-3' },
+    });
+
+    mockGetMysqlDatabase.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 'db-3',
+        name: 'db-3',
+        hostname: 'db-3.mysql.mittwald.de',
+        externalHostname: 'ext-db-3.mysql.mittwald.de',
+        mainUser: undefined,
+      },
+    });
+
+    mockListMysqlUsers.mockResolvedValue({
+      status: 200,
+      data: [],
+    });
+
+    const result = await createMysqlDatabase(baseOptions);
+
+    expect(result.data.userName).toBe('');
+  });
+
+  it('falls back to an empty string without throwing when the follow-up listMysqlUsers call itself fails', async () => {
+    mockCreateMysqlDatabase.mockResolvedValue({
+      status: 201,
+      data: { id: 'db-4', userId: 'user-4' },
+    });
+
+    mockGetMysqlDatabase.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 'db-4',
+        name: 'db-4',
+        hostname: 'db-4.mysql.mittwald.de',
+        externalHostname: 'ext-db-4.mysql.mittwald.de',
+        mainUser: undefined,
+      },
+    });
+
+    mockListMysqlUsers.mockRejectedValue(new Error('network error'));
+
+    const result = await createMysqlDatabase(baseOptions);
+
+    expect(result.data.userName).toBe('');
+  });
+});

--- a/packages/mittwald-cli-core/src/resources/database-mysql.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.ts
@@ -88,16 +88,6 @@ function generateMySqlUserPassword(): string {
   return chars.join('');
 }
 
-// Right after `createMysqlDatabase` succeeds, `getMysqlDatabase` can briefly return the new
-// database without its `mainUser` relation populated (eventual consistency on the API side).
-// Poll the same endpoint a few more times, with exponential backoff, rather than surfacing an
-// empty username. Bounded so a slow/never-converging backend can't hang the tool call: worst
-// case is MYSQL_USERNAME_POLL_MAX_ATTEMPTS extra requests, with delays growing from
-// MYSQL_USERNAME_POLL_INITIAL_DELAY_MS up to MYSQL_USERNAME_POLL_MAX_DELAY_MS between them.
-const MYSQL_USERNAME_POLL_MAX_ATTEMPTS = 4;
-const MYSQL_USERNAME_POLL_INITIAL_DELAY_MS = 100;
-const MYSQL_USERNAME_POLL_MAX_DELAY_MS = 2000;
-
 export interface CreateMysqlDatabaseResult {
   /** The database ID */
   id: string;
@@ -160,12 +150,13 @@ export async function createMysqlDatabase(options: CreateMysqlDatabaseOptions): 
 
     const dbDetails = getResponse.data;
 
-    // See the comment on MYSQL_USERNAME_POLL_MAX_ATTEMPTS above: poll getMysqlDatabase — the same
-    // endpoint we just called — until mainUser.name shows up, rather than reading it once. A
-    // fallback read from a different endpoint (e.g. listMysqlUsers) wouldn't help here: it reads
-    // the same not-yet-converged backend state, so it can race the same way getMysqlDatabase did.
-    // Best-effort only: if the budget is exhausted before the username appears, fall back to ''
-    // as before rather than throwing (retryOnError so a transient error on one poll attempt
+    // Right after creation, `getMysqlDatabase` can briefly return the new database without its
+    // `mainUser` relation populated (eventual consistency on the API side). Poll the same
+    // endpoint — with exponential backoff — until mainUser.name shows up, rather than reading it
+    // once. A fallback read from a different endpoint (e.g. listMysqlUsers) wouldn't help here: it
+    // reads the same not-yet-converged backend state, so it can race the same way getMysqlDatabase
+    // did. Best-effort only: if the budget is exhausted before the username appears, fall back to
+    // '' as before rather than throwing (retryOnError so a transient error on one poll attempt
     // doesn't abort the remaining ones either).
     let userName = dbDetails.mainUser?.name ?? '';
     if (!userName) {
@@ -179,12 +170,7 @@ export async function createMysqlDatabase(options: CreateMysqlDatabaseOptions): 
             return pollResponse.data.mainUser?.name ?? '';
           },
           (name) => Boolean(name),
-          {
-            maxAttempts: MYSQL_USERNAME_POLL_MAX_ATTEMPTS,
-            initialDelayMs: MYSQL_USERNAME_POLL_INITIAL_DELAY_MS,
-            maxDelayMs: MYSQL_USERNAME_POLL_MAX_DELAY_MS,
-            retryOnError: true,
-          }
+          { maxAttempts: 4, initialDelayMs: 100, maxDelayMs: 2000, retryOnError: true }
         )) ?? '';
     }
 

--- a/packages/mittwald-cli-core/src/resources/database-mysql.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.ts
@@ -7,7 +7,6 @@ import { assertStatus } from '@mittwald/api-client-commons';
 import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 import { randomBytes } from 'node:crypto';
-import { listMysqlUsers } from './database-mysql-user.js';
 
 export interface ListMysqlDatabasesOptions extends LibraryFunctionBase {
   projectId: string;
@@ -88,6 +87,19 @@ function generateMySqlUserPassword(): string {
   return chars.join('');
 }
 
+// Right after `createMysqlDatabase` succeeds, `getMysqlDatabase` can briefly return the new
+// database without its `mainUser` relation populated (eventual consistency on the API side).
+// Poll the same endpoint a few more times with a short delay rather than surfacing an empty
+// username. Bounded so a slow/never-converging backend can't hang the tool call: worst case is
+// MYSQL_USERNAME_POLL_MAX_ATTEMPTS - 1 extra requests spread over roughly
+// (MYSQL_USERNAME_POLL_MAX_ATTEMPTS - 1) * MYSQL_USERNAME_POLL_INTERVAL_MS.
+const MYSQL_USERNAME_POLL_MAX_ATTEMPTS = 5;
+const MYSQL_USERNAME_POLL_INTERVAL_MS = 400;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export interface CreateMysqlDatabaseResult {
   /** The database ID */
   id: string;
@@ -150,23 +162,23 @@ export async function createMysqlDatabase(options: CreateMysqlDatabaseOptions): 
 
     const dbDetails = getResponse.data;
 
-    // Right after creation, the freshly-created database's `mainUser` relation is often not yet
-    // populated (eventual consistency on the API side). Fall back to a follow-up listMysqlUsers
-    // call to resolve the real username instead of surfacing an empty string. Best-effort only:
-    // if this also fails to find the user, fall back to '' as before rather than throwing.
+    // See the comment on MYSQL_USERNAME_POLL_MAX_ATTEMPTS above: poll getMysqlDatabase — the same
+    // endpoint we just called — until mainUser.name shows up, rather than reading it once. A
+    // fallback read from a different endpoint (e.g. listMysqlUsers) wouldn't help here: it reads
+    // the same not-yet-converged backend state, so it can race the same way getMysqlDatabase did.
+    // Best-effort only: if the budget is exhausted before the username appears, fall back to ''
+    // as before rather than throwing.
     let userName = dbDetails.mainUser?.name ?? '';
-    if (!userName) {
+    for (let attempt = 1; !userName && attempt < MYSQL_USERNAME_POLL_MAX_ATTEMPTS; attempt++) {
+      await delay(MYSQL_USERNAME_POLL_INTERVAL_MS);
       try {
-        const usersResponse = await listMysqlUsers({
-          databaseId: createResponse.data.id,
-          apiToken: options.apiToken,
+        const pollResponse = await client.database.getMysqlDatabase({
+          mysqlDatabaseId: createResponse.data.id,
         });
-        const mainUser = usersResponse.data.find(
-          (user) => user.id === createResponse.data.userId || user.mainUser === true
-        );
-        userName = mainUser?.name ?? '';
+        assertStatus(pollResponse, 200);
+        userName = pollResponse.data.mainUser?.name ?? '';
       } catch {
-        // Best-effort enrichment — keep userName as '' if the follow-up lookup fails.
+        // Best-effort enrichment — keep polling; if every attempt fails, userName stays ''.
       }
     }
 

--- a/packages/mittwald-cli-core/src/resources/database-mysql.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.ts
@@ -7,6 +7,7 @@ import { assertStatus } from '@mittwald/api-client-commons';
 import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 import { randomBytes } from 'node:crypto';
+import { listMysqlUsers } from './database-mysql-user.js';
 
 export interface ListMysqlDatabasesOptions extends LibraryFunctionBase {
   projectId: string;
@@ -149,13 +150,33 @@ export async function createMysqlDatabase(options: CreateMysqlDatabaseOptions): 
 
     const dbDetails = getResponse.data;
 
+    // Right after creation, the freshly-created database's `mainUser` relation is often not yet
+    // populated (eventual consistency on the API side). Fall back to a follow-up listMysqlUsers
+    // call to resolve the real username instead of surfacing an empty string. Best-effort only:
+    // if this also fails to find the user, fall back to '' as before rather than throwing.
+    let userName = dbDetails.mainUser?.name ?? '';
+    if (!userName) {
+      try {
+        const usersResponse = await listMysqlUsers({
+          databaseId: createResponse.data.id,
+          apiToken: options.apiToken,
+        });
+        const mainUser = usersResponse.data.find(
+          (user) => user.id === createResponse.data.userId || user.mainUser === true
+        );
+        userName = mainUser?.name ?? '';
+      } catch {
+        // Best-effort enrichment — keep userName as '' if the follow-up lookup fails.
+      }
+    }
+
     const result: CreateMysqlDatabaseResult = {
       id: createResponse.data.id,
       userId: createResponse.data.userId,
       name: dbDetails.name,
       hostname: dbDetails.hostname,
       externalHostname: dbDetails.externalHostname,
-      userName: dbDetails.mainUser?.name ?? '',
+      userName,
       passwordWasGenerated,
       // Only include password if it was auto-generated (security: don't echo back user-provided passwords)
       ...(passwordWasGenerated ? { password } : {}),

--- a/packages/mittwald-cli-core/src/resources/database-mysql.ts
+++ b/packages/mittwald-cli-core/src/resources/database-mysql.ts
@@ -7,6 +7,7 @@ import { assertStatus } from '@mittwald/api-client-commons';
 import { libraryErrorFromApiError } from '../contracts/functions.js';
 import type { LibraryFunctionBase, LibraryResult } from '../contracts/functions.js';
 import { randomBytes } from 'node:crypto';
+import { poll } from '../lib/poll.js';
 
 export interface ListMysqlDatabasesOptions extends LibraryFunctionBase {
   projectId: string;
@@ -89,16 +90,13 @@ function generateMySqlUserPassword(): string {
 
 // Right after `createMysqlDatabase` succeeds, `getMysqlDatabase` can briefly return the new
 // database without its `mainUser` relation populated (eventual consistency on the API side).
-// Poll the same endpoint a few more times with a short delay rather than surfacing an empty
-// username. Bounded so a slow/never-converging backend can't hang the tool call: worst case is
-// MYSQL_USERNAME_POLL_MAX_ATTEMPTS - 1 extra requests spread over roughly
-// (MYSQL_USERNAME_POLL_MAX_ATTEMPTS - 1) * MYSQL_USERNAME_POLL_INTERVAL_MS.
-const MYSQL_USERNAME_POLL_MAX_ATTEMPTS = 5;
-const MYSQL_USERNAME_POLL_INTERVAL_MS = 400;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+// Poll the same endpoint a few more times, with exponential backoff, rather than surfacing an
+// empty username. Bounded so a slow/never-converging backend can't hang the tool call: worst
+// case is MYSQL_USERNAME_POLL_MAX_ATTEMPTS extra requests, with delays growing from
+// MYSQL_USERNAME_POLL_INITIAL_DELAY_MS up to MYSQL_USERNAME_POLL_MAX_DELAY_MS between them.
+const MYSQL_USERNAME_POLL_MAX_ATTEMPTS = 4;
+const MYSQL_USERNAME_POLL_INITIAL_DELAY_MS = 100;
+const MYSQL_USERNAME_POLL_MAX_DELAY_MS = 2000;
 
 export interface CreateMysqlDatabaseResult {
   /** The database ID */
@@ -167,19 +165,27 @@ export async function createMysqlDatabase(options: CreateMysqlDatabaseOptions): 
     // fallback read from a different endpoint (e.g. listMysqlUsers) wouldn't help here: it reads
     // the same not-yet-converged backend state, so it can race the same way getMysqlDatabase did.
     // Best-effort only: if the budget is exhausted before the username appears, fall back to ''
-    // as before rather than throwing.
+    // as before rather than throwing (retryOnError so a transient error on one poll attempt
+    // doesn't abort the remaining ones either).
     let userName = dbDetails.mainUser?.name ?? '';
-    for (let attempt = 1; !userName && attempt < MYSQL_USERNAME_POLL_MAX_ATTEMPTS; attempt++) {
-      await delay(MYSQL_USERNAME_POLL_INTERVAL_MS);
-      try {
-        const pollResponse = await client.database.getMysqlDatabase({
-          mysqlDatabaseId: createResponse.data.id,
-        });
-        assertStatus(pollResponse, 200);
-        userName = pollResponse.data.mainUser?.name ?? '';
-      } catch {
-        // Best-effort enrichment — keep polling; if every attempt fails, userName stays ''.
-      }
+    if (!userName) {
+      userName =
+        (await poll(
+          async () => {
+            const pollResponse = await client.database.getMysqlDatabase({
+              mysqlDatabaseId: createResponse.data.id,
+            });
+            assertStatus(pollResponse, 200);
+            return pollResponse.data.mainUser?.name ?? '';
+          },
+          (name) => Boolean(name),
+          {
+            maxAttempts: MYSQL_USERNAME_POLL_MAX_ATTEMPTS,
+            initialDelayMs: MYSQL_USERNAME_POLL_INITIAL_DELAY_MS,
+            maxDelayMs: MYSQL_USERNAME_POLL_MAX_DELAY_MS,
+            retryOnError: true,
+          }
+        )) ?? '';
     }
 
     const result: CreateMysqlDatabaseResult = {


### PR DESCRIPTION
## Summary

`mittwald_database_mysql_create` was returning an empty `userName` in its result. The actual
username (a `dbu_...` string) was only discoverable via a follow-up `mittwald_database_mysql_user_list`
call. This was flagged in code review as an informational-severity issue.

**Root cause:** `createMysqlDatabase` in `packages/mittwald-cli-core/src/resources/database-mysql.ts`
calls `client.database.createMysqlDatabase(...)` (creates the DB + default user in one call), then
immediately calls `client.database.getMysqlDatabase(...)` to read back hostname/name/user details and
sets `userName: dbDetails.mainUser?.name ?? ''`. Right after creation, the freshly-created database's
`mainUser` relation (optional per the generated API types) is often not yet populated — an
eventual-consistency gap on the API side — so `mainUser` comes back `undefined` and `userName` falls
back to `''`.

**Fix history on this PR:**
1. First attempt fell back to a `listMysqlUsers` call when `mainUser` was missing. Review correctly
   pointed out that this doesn't fix the race: `getMysqlDatabase` and `listMysqlUsers` read the same
   not-yet-converged backend state, so a fallback read from a different endpoint can still return
   without the username — or appear to work in testing purely by accident of timing, then flake in
   production.
2. Second attempt polled `getMysqlDatabase` (the same endpoint) inline in `createMysqlDatabase`, with
   a fixed 400ms interval. Review correctly pointed out that (a) this polling behavior will be needed
   elsewhere and shouldn't be coded directly into one tool, and (b) a fixed 400ms first-retry delay is
   unnecessarily slow — exponential backoff starting much shorter is the better shape.

**Current approach:** before writing more code, I checked the rest of the codebase for existing
polling/retry patterns to reuse or align with:
- Cronjob execution (`executeCronjob`) is fire-and-forget — no internal polling for completion.
- Stack/container lifecycle operations (`resources/stack.ts`, `resources/container.ts`) don't poll for
  a settled status.
- `getBackupDownloadUrl` in `resources/backup.ts` documents a deliberate *outer-loop* pattern instead:
  "Exports are prepared asynchronously... callers poll by calling this again" — i.e. the MCP tool
  caller re-invokes the tool, rather than the library function blocking internally. That's an
  intentional, different design for long-running async jobs and isn't a fit for this sub-second
  consistency gap.
- The only existing polling code is `waitUntil()` in `packages/mittwald-cli-core/src/lib/wait.ts`,
  used exclusively by the legacy oclif `mw app install --wait` flow (`lib/resources/app/wait.tsx` ->
  `Installer.tsx`): fixed 1s interval, 600s default timeout, throws on timeout. Not directly reusable
  as-is (no backoff, no non-throwing mode), but a reasonable base to generalize instead of writing a
  second, competing loop.

Extracted the core loop into a new **`poll<T>()`** utility in `packages/mittwald-cli-core/src/lib/poll.ts`:
- `poll(fn, isReady, options): Promise<T | undefined>`, with exponential backoff — `initialDelayMs`,
  `backoffFactor`, `maxDelayMs`, `maxAttempts` are all configurable (defaults: 100ms / ×2 / 5000ms / 5
  attempts).
- `retryOnError` controls whether an error thrown by `fn()` aborts immediately (default, matches the
  original `waitUntil` behavior) or is swallowed and retried (what `createMysqlDatabase` needs for
  best-effort enrichment).
- `throwOnExhausted` (typed via call-signature overloads on a single `const poll = ... as {...}`, to
  keep plain ESLint's `no-redeclare` — which doesn't understand TS overload syntax — happy) lets a
  caller opt into a thrown `PollTimeoutError` instead of getting `undefined` back once the attempt
  budget runs out.
- `delayFn` is injectable so tests can drive it with vitest fake timers instead of sleeping for real
  wall-clock time.

`waitUntil()` is now a thin, backward-compatible wrapper around `poll()` — same signature, same fixed
~1s cadence, same throw-on-timeout behavior — so there's a single polling implementation instead of
two competing ones.

`createMysqlDatabase` now calls `poll()` instead of its own loop: up to 4 extra `getMysqlDatabase`
reads, starting at 100ms and doubling up to a 2s cap, `retryOnError: true`. Still best-effort: if the
budget is exhausted, `userName` falls back to `''` as before rather than throwing.

The public `CreateMysqlDatabaseResult` shape is unchanged.

## Test plan

- [x] Added `packages/mittwald-cli-core/src/lib/poll.test.ts` covering the utility generically:
      resolves on the first attempt; resolves after N attempts; exponential backoff timing and the
      `maxDelayMs` cap; resolves `undefined` vs. throws `PollTimeoutError` depending on
      `throwOnExhausted` once the budget is exhausted; propagates vs. retries past an error from `fn()`
      depending on `retryOnError`.
- [x] Updated `packages/mittwald-cli-core/src/resources/database-mysql.test.ts` to match the new call
      shape: no extra polling when `mainUser` is already populated; resolves via `poll()` on a later
      attempt (asserting the concrete 100ms → 200ms backoff schedule via fake timers); gives up
      gracefully (`''`) once the poll budget is exhausted; survives a transient error mid-poll; gives
      up gracefully when every poll attempt errors. Nothing in the suite sleeps for real wall-clock
      time.
- [x] `npm run build:all`
- [x] `npm run type-check`
- [x] `npm run lint` (no new issues on the changed source files; pre-existing unrelated lint errors on
      `main` untouched)
- [x] `npx vitest run tests/unit packages/mittwald-cli-core` — 370 tests passing; only the same 9
      pre-existing, unrelated failures remain (files under `packages/mittwald-cli-core` that import
      `@jest/globals` under the Vitest runner — broken on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
